### PR TITLE
docs: add repository module docs

### DIFF
--- a/src/bin/check_reply.rs
+++ b/src/bin/check_reply.rs
@@ -319,6 +319,7 @@ fn monitor_hub(repo: DieselRepository, hub: Hub, domain: String, zmq_sender: &Zm
     }
 }
 
+/// Entry point for the reply-checking worker.
 #[tokio::main]
 async fn main() {
     env_logger::init_from_env(env_logger::Env::default().default_filter_or("info"));

--- a/src/bin/send_email.rs
+++ b/src/bin/send_email.rs
@@ -157,6 +157,7 @@ async fn send_email(
     Ok(())
 }
 
+/// Entry point for the email sender worker.
 #[tokio::main]
 async fn main() {
     env_logger::init_from_env(env_logger::Env::default().default_filter_or("info"));

--- a/src/repository/email.rs
+++ b/src/repository/email.rs
@@ -1,3 +1,8 @@
+//! Email repository implementation backed by Diesel.
+//!
+//! Provides [`EmailReader`] and [`EmailWriter`] trait implementations for
+//! [`DieselRepository`].
+
 use diesel::prelude::*;
 use pushkind_common::domain::emailer::email::{
     EmailRecipient as DomainEmailRecipient, EmailWithRecipients as DomainEmailWithRecipients,

--- a/src/repository/hub.rs
+++ b/src/repository/hub.rs
@@ -1,3 +1,7 @@
+//! Hub repository implementation backed by Diesel.
+//!
+//! Supplies the [`HubReader`] trait for [`DieselRepository`].
+
 use diesel::prelude::*;
 use pushkind_common::domain::emailer::hub::Hub as DomainHub;
 use pushkind_common::models::emailer::hub::Hub as DbHub;

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -1,3 +1,9 @@
+//! Repository interfaces and Diesel-backed implementation.
+//!
+//! This module defines traits for reading and writing email and hub data
+//! alongside [`DieselRepository`], a small wrapper around a Diesel
+//! connection pool.
+
 use pushkind_common::db::{DbConnection, DbPool};
 use pushkind_common::domain::emailer::email::{
     EmailRecipient, EmailWithRecipients, NewEmail, UpdateEmailRecipient,
@@ -8,12 +14,14 @@ use pushkind_common::repository::errors::RepositoryResult;
 pub mod email;
 pub mod hub;
 
+/// Concrete repository backed by a Diesel connection pool.
 #[derive(Clone)]
 pub struct DieselRepository {
     pool: DbPool, // r2d2::Pool is cheap to clone
 }
 
 impl DieselRepository {
+    /// Creates a new [`DieselRepository`] from the given pool.
     pub fn new(pool: DbPool) -> Self {
         Self { pool }
     }
@@ -23,24 +31,49 @@ impl DieselRepository {
     }
 }
 
+/// Read-only operations for email entities.
 pub trait EmailReader {
+    /// Fetches an email with its recipients by ID constrained by `hub_id`.
     fn get_email_by_id(
         &self,
         id: i32,
         hub_id: i32,
     ) -> RepositoryResult<Option<EmailWithRecipients>>;
+
+    /// Lists recipients that have not replied within the hub.
     fn list_not_replied_email_recipients(
         &self,
         hub_id: i32,
     ) -> RepositoryResult<Vec<EmailRecipient>>;
+
+    /// Retrieves a recipient by ID if it belongs to the hub.
     fn get_email_recipient_by_id(
         &self,
         id: i32,
         hub_id: i32,
     ) -> RepositoryResult<Option<EmailRecipient>>;
 }
+
+/// Write operations for email entities.
 pub trait EmailWriter {
+    /// Persists a new email and its recipients.
     fn create_email(&self, email: &NewEmail) -> RepositoryResult<EmailWithRecipients>;
+
+    /// Updates a single recipient and returns the refreshed email state.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use pushkind_common::domain::emailer::email::UpdateEmailRecipient;
+    /// use pushkind_hedwig::repository::{DieselRepository, EmailWriter};
+    /// # fn demo(repo: &DieselRepository) {
+    /// let _ = repo.update_recipient(1, &UpdateEmailRecipient {
+    ///     is_sent: Some(true),
+    ///     replied: None,
+    ///     opened: None,
+    ///     reply: None,
+    /// });
+    /// # }
+    /// ```
     fn update_recipient(
         &self,
         recipient_id: i32,
@@ -48,7 +81,11 @@ pub trait EmailWriter {
     ) -> RepositoryResult<EmailWithRecipients>;
 }
 
+/// Read-only operations for hubs.
 pub trait HubReader {
+    /// Retrieves a hub by its identifier.
     fn get_hub_by_id(&self, id: i32) -> RepositoryResult<Option<Hub>>;
+
+    /// Lists all hubs stored in the repository.
     fn list_hubs(&self) -> RepositoryResult<Vec<Hub>>;
 }


### PR DESCRIPTION
## Summary
- document repository modules and traits
- add usage example for `update_recipient`
- describe entry points for email worker binaries

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --tests -- -Dwarnings`
- `cargo build --all-features --verbose`
- `cargo test --all-features --verbose`

------
https://chatgpt.com/codex/tasks/task_e_68b6e31c1320832a9b6e8d87f3c1dc49