### PR TITLE
Refactored: handle misconfigured hub gracefully

### DIFF
--- a/src/check_reply/mod.rs
+++ b/src/check_reply/mod.rs
@@ -37,11 +37,9 @@ pub async fn run(database_url: &str, domain: &str, zmq_address: &str) -> Result<
             Ok(Ok(())) => {}
             Ok(Err(e)) => {
                 log::error!("monitor_hub failed: {e}");
-                return Err(e);
             }
             Err(e) => {
                 log::error!("Task panicked: {e:?}");
-                return Err(Error::Config(format!("task panicked: {e:?}")));
             }
         }
     }


### PR DESCRIPTION
## Summary
- avoid aborting all hub monitors when a hub lacks IMAP settings or session init fails
- log monitor_hub errors without terminating other monitors

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --tests -- -Dwarnings`
- `cargo build --all-features --verbose`
- `cargo test --all-features --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68b73a904764832a912f07830e328303