### PR TITLE
Add unit tests for email workflows and repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,6 +779,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1932,6 +1938,7 @@ dependencies = [
  "pushkind-common",
  "rustls",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.16",
  "tokio",
  "tokio-rustls",
@@ -2482,6 +2489,19 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "tempfile"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix 1.0.8",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "tendril"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,6 @@ html2text = "0.15.3"
 thiserror = "2.0.16"
 async-trait = "0.1"
 futures = "0.3"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/send_email/service.rs
+++ b/src/send_email/service.rs
@@ -94,3 +94,139 @@ where
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use crate::repository::DieselRepository;
+    use diesel::{RunQueryDsl, connection::SimpleConnection};
+    use pushkind_common::db::establish_connection_pool;
+    use pushkind_common::domain::emailer::email::{NewEmail, NewEmailRecipient};
+    use pushkind_common::models::emailer::hub::NewHub as DbNewHub;
+    use pushkind_common::schema::emailer::hubs;
+    use tempfile::TempDir;
+
+    struct MockMailer {
+        calls: Arc<AtomicUsize>,
+        fail: bool,
+    }
+
+    #[async_trait]
+    impl Mailer for MockMailer {
+        async fn send(&self, _hub: &Hub, _message: MessageBuilder<'_>) -> Result<(), Error> {
+            if self.fail {
+                Err(Error::Config("fail".into()))
+            } else {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+    }
+
+    fn setup_pool() -> (TempDir, pushkind_common::db::DbPool) {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let pool = establish_connection_pool(db_path.to_str().unwrap()).unwrap();
+        {
+            let mut conn = pool.get().unwrap();
+            conn.batch_execute(
+                "CREATE TABLE hubs (id INTEGER PRIMARY KEY, login TEXT, password TEXT, sender TEXT, smtp_server TEXT, smtp_port INTEGER, created_at TIMESTAMP, updated_at TIMESTAMP, imap_server TEXT, imap_port INTEGER, email_template TEXT);\n\
+                 CREATE TABLE emails (id INTEGER PRIMARY KEY, message TEXT NOT NULL, created_at TIMESTAMP NOT NULL, is_sent BOOL NOT NULL, subject TEXT, attachment BLOB, attachment_name TEXT, attachment_mime TEXT, num_sent INTEGER NOT NULL DEFAULT 0, num_opened INTEGER NOT NULL DEFAULT 0, num_replied INTEGER NOT NULL DEFAULT 0, hub_id INTEGER NOT NULL REFERENCES hubs(id));\n\
+                 CREATE TABLE email_recipients (id INTEGER PRIMARY KEY, email_id INTEGER NOT NULL REFERENCES emails(id), address TEXT NOT NULL, opened BOOL NOT NULL, updated_at TIMESTAMP NOT NULL, is_sent BOOL NOT NULL, replied BOOL NOT NULL, name TEXT, reply TEXT);"
+            ).unwrap();
+        }
+        (dir, pool)
+    }
+
+    fn insert_hub(pool: &pushkind_common::db::DbPool) {
+        let mut conn = pool.get().unwrap();
+        let hub = DbNewHub {
+            id: 1,
+            login: Some("sender@example.com"),
+            password: Some("pass"),
+            sender: Some("sender@example.com"),
+            smtp_server: None,
+            smtp_port: None,
+            created_at: None,
+            updated_at: None,
+            imap_server: None,
+            imap_port: None,
+            email_template: Some("Hi {name}! {message}"),
+        };
+        diesel::insert_into(hubs::table)
+            .values(&hub)
+            .execute(&mut conn)
+            .unwrap();
+    }
+
+    fn create_email(repo: &DieselRepository) -> (i32, i32) {
+        let new_email = NewEmail {
+            message: "Hello".into(),
+            subject: None,
+            attachment: None,
+            attachment_name: None,
+            attachment_mime: None,
+            hub_id: 1,
+            recipients: vec![NewEmailRecipient {
+                address: "to@example.com".into(),
+                name: None,
+            }],
+        };
+        let stored = repo.create_email(&new_email).unwrap();
+        (stored.email.id, stored.recipients[0].id)
+    }
+
+    #[tokio::test]
+    async fn send_email_updates_recipient_on_success() {
+        let (_dir, pool) = setup_pool();
+        insert_hub(&pool);
+        let repo = DieselRepository::new(pool.clone());
+        let (email_id, recipient_id) = create_email(&repo);
+
+        let mailer = MockMailer {
+            calls: Arc::new(AtomicUsize::new(0)),
+            fail: false,
+        };
+        let msg = ZMQSendEmailMessage::RetryEmail((email_id, 1));
+        send_email(msg, &repo, "example.com", &mailer)
+            .await
+            .unwrap();
+        assert_eq!(mailer.calls.load(Ordering::SeqCst), 1);
+
+        let updated = repo
+            .get_email_recipient_by_id(recipient_id, 1)
+            .unwrap()
+            .unwrap();
+        assert!(updated.is_sent);
+    }
+
+    #[tokio::test]
+    async fn send_email_skips_update_on_failure() {
+        let (_dir, pool) = setup_pool();
+        insert_hub(&pool);
+        let repo = DieselRepository::new(pool.clone());
+        let (email_id, recipient_id) = create_email(&repo);
+
+        let mailer = MockMailer {
+            calls: Arc::new(AtomicUsize::new(0)),
+            fail: true,
+        };
+        let msg = ZMQSendEmailMessage::RetryEmail((email_id, 1));
+        send_email(msg, &repo, "example.com", &mailer)
+            .await
+            .unwrap();
+        assert_eq!(mailer.calls.load(Ordering::SeqCst), 0);
+
+        let updated = repo
+            .get_email_recipient_by_id(recipient_id, 1)
+            .unwrap()
+            .unwrap();
+        assert!(!updated.is_sent);
+    }
+}

--- a/tests/repository.rs
+++ b/tests/repository.rs
@@ -1,0 +1,127 @@
+use diesel::{RunQueryDsl, connection::SimpleConnection};
+use pushkind_common::db::establish_connection_pool;
+use pushkind_common::domain::emailer::email::{NewEmail, NewEmailRecipient, UpdateEmailRecipient};
+use pushkind_common::models::emailer::hub::NewHub as DbNewHub;
+use pushkind_common::schema::emailer::hubs;
+use pushkind_hedwig::repository::{DieselRepository, EmailReader, EmailWriter, HubReader};
+use tempfile::TempDir;
+
+fn setup_pool() -> (TempDir, pushkind_common::db::DbPool) {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let pool = establish_connection_pool(db_path.to_str().unwrap()).unwrap();
+    {
+        let mut conn = pool.get().unwrap();
+        conn.batch_execute(
+            "CREATE TABLE hubs (id INTEGER PRIMARY KEY, login TEXT, password TEXT, sender TEXT, smtp_server TEXT, smtp_port INTEGER, created_at TIMESTAMP, updated_at TIMESTAMP, imap_server TEXT, imap_port INTEGER, email_template TEXT);\n\
+             CREATE TABLE emails (id INTEGER PRIMARY KEY, message TEXT NOT NULL, created_at TIMESTAMP NOT NULL, is_sent BOOL NOT NULL, subject TEXT, attachment BLOB, attachment_name TEXT, attachment_mime TEXT, num_sent INTEGER NOT NULL DEFAULT 0, num_opened INTEGER NOT NULL DEFAULT 0, num_replied INTEGER NOT NULL DEFAULT 0, hub_id INTEGER NOT NULL REFERENCES hubs(id));\n\
+             CREATE TABLE email_recipients (id INTEGER PRIMARY KEY, email_id INTEGER NOT NULL REFERENCES emails(id), address TEXT NOT NULL, opened BOOL NOT NULL, updated_at TIMESTAMP NOT NULL, is_sent BOOL NOT NULL, replied BOOL NOT NULL, name TEXT, reply TEXT);"
+        ).unwrap();
+    }
+    (dir, pool)
+}
+
+fn insert_hub(pool: &pushkind_common::db::DbPool) {
+    let mut conn = pool.get().unwrap();
+    let hub = DbNewHub {
+        id: 1,
+        login: Some("sender@example.com"),
+        password: Some("pass"),
+        sender: Some("sender@example.com"),
+        smtp_server: None,
+        smtp_port: None,
+        created_at: None,
+        updated_at: None,
+        imap_server: None,
+        imap_port: None,
+        email_template: Some("Hi {name}! {message}"),
+    };
+    diesel::insert_into(hubs::table)
+        .values(&hub)
+        .execute(&mut conn)
+        .unwrap();
+}
+
+fn create_email(repo: &DieselRepository) -> (i32, i32) {
+    let new_email = NewEmail {
+        message: "Hello".into(),
+        subject: Some("Subject".into()),
+        attachment: None,
+        attachment_name: None,
+        attachment_mime: None,
+        hub_id: 1,
+        recipients: vec![NewEmailRecipient {
+            address: "to@example.com".into(),
+            name: Some("Alice".into()),
+        }],
+    };
+    let stored = repo.create_email(&new_email).unwrap();
+    (stored.email.id, stored.recipients[0].id)
+}
+
+#[test]
+fn create_and_get_email() {
+    let (_dir, pool) = setup_pool();
+    insert_hub(&pool);
+    let repo = DieselRepository::new(pool.clone());
+    let (email_id, recipient_id) = create_email(&repo);
+
+    let fetched = repo.get_email_by_id(email_id, 1).unwrap().unwrap();
+    assert_eq!(fetched.recipients.len(), 1);
+    assert_eq!(fetched.recipients[0].id, recipient_id);
+}
+
+#[test]
+fn list_and_get_recipient() {
+    let (_dir, pool) = setup_pool();
+    insert_hub(&pool);
+    let repo = DieselRepository::new(pool.clone());
+    let (email_id, recipient_id) = create_email(&repo);
+
+    let list = repo.list_not_replied_email_recipients(1).unwrap();
+    assert_eq!(list.len(), 1);
+    let rec = repo
+        .get_email_recipient_by_id(recipient_id, 1)
+        .unwrap()
+        .unwrap();
+    assert_eq!(rec.email_id, email_id);
+}
+
+#[test]
+fn update_recipient_updates_stats() {
+    let (_dir, pool) = setup_pool();
+    insert_hub(&pool);
+    let repo = DieselRepository::new(pool.clone());
+    let (email_id, recipient_id) = create_email(&repo);
+
+    repo.update_recipient(
+        recipient_id,
+        &UpdateEmailRecipient {
+            is_sent: Some(true),
+            opened: Some(true),
+            replied: Some(true),
+            reply: Some("Thanks".into()),
+        },
+    )
+    .unwrap();
+
+    let updated = repo.get_email_by_id(email_id, 1).unwrap().unwrap();
+    let rec = &updated.recipients[0];
+    assert!(rec.is_sent && rec.opened && rec.replied);
+    assert_eq!(rec.reply.as_deref(), Some("Thanks"));
+    assert_eq!(updated.email.num_sent, 1);
+    assert_eq!(updated.email.num_opened, 1);
+    assert_eq!(updated.email.num_replied, 1);
+}
+
+#[test]
+fn hub_queries() {
+    let (_dir, pool) = setup_pool();
+    insert_hub(&pool);
+    let repo = DieselRepository::new(pool.clone());
+
+    let hub = repo.get_hub_by_id(1).unwrap().unwrap();
+    assert_eq!(hub.id, 1);
+    let hubs = repo.list_hubs().unwrap();
+    assert_eq!(hubs.len(), 1);
+}


### PR DESCRIPTION
## Summary
- add unit tests for message building and send_email service
- test repository operations against SQLite fixtures
- enable temp file support for tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --tests -- -Dwarnings`
- `cargo test --all-features --verbose`
- `cargo build --all-features --verbose`

------
https://chatgpt.com/codex/tasks/task_e_68b6d3bc6744832aa7535b990228f069