### PR TITLE
Handle unsubscribe and undelivered emails via ZMQ

### DIFF
--- a/src/check_reply/service.rs
+++ b/src/check_reply/service.rs
@@ -2,10 +2,12 @@ use std::str;
 
 use async_imap::Session;
 use futures::StreamExt;
+use once_cell::sync::Lazy;
 use pushkind_common::domain::emailer::email::{EmailRecipient, UpdateEmailRecipient};
 use pushkind_common::domain::emailer::hub::Hub;
-use pushkind_common::models::emailer::zmq::ZMQReplyMessage;
+use pushkind_common::models::emailer::zmq::{ZMQReplyMessage, ZMQUnsubscribeMessage};
 use pushkind_common::zmq::ZmqSender;
+use regex::Regex;
 use tokio::net::TcpStream;
 use tokio::time::{Duration, sleep};
 use tokio_rustls::client::TlsStream;
@@ -15,6 +17,109 @@ use crate::repository::{DieselRepository, EmailReader, EmailWriter};
 
 use super::imap::{fetch_message_body, init_session};
 use super::parser::{extract_plain_reply, extract_recipient_id};
+
+static EMAIL_REGEX: Lazy<Option<Regex>> =
+    Lazy::new(|| Regex::new(r"(?i)[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}").ok());
+
+fn extract_header_value(header: &str, name: &str) -> Option<String> {
+    let mut collected = String::new();
+    let mut found = false;
+    let header_name = format!("{}:", name.to_ascii_lowercase());
+
+    for raw_line in header.lines() {
+        let line = raw_line.trim_end_matches('\r');
+        if found {
+            if line.starts_with(' ') || line.starts_with('\t') {
+                if !collected.is_empty() {
+                    collected.push(' ');
+                }
+                collected.push_str(line.trim());
+                continue;
+            }
+            break;
+        }
+
+        let lower_line = line.to_ascii_lowercase();
+        if lower_line.starts_with(&header_name)
+            && let Some((_, value)) = line.split_once(':')
+        {
+            collected.push_str(value.trim());
+            found = true;
+        }
+    }
+
+    if found { Some(collected) } else { None }
+}
+
+fn extract_email_address(input: &str) -> Option<String> {
+    match &*EMAIL_REGEX {
+        Some(regex) => regex.find(input).map(|m| m.as_str().to_string()),
+        None => {
+            log::error!("Email regex failed to compile");
+            None
+        }
+    }
+}
+
+fn extract_sender_email(header: &str) -> Option<String> {
+    for field in ["Sender", "From"] {
+        if let Some(value) = extract_header_value(header, field)
+            && let Some(email) = extract_email_address(&value)
+        {
+            return Some(email);
+        }
+    }
+    None
+}
+
+fn extract_bounce_recipient(body: &str) -> Option<String> {
+    let mut fallback = None;
+
+    for raw_line in body.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if let Some(email) = extract_email_address(line) {
+            let lower = line.to_ascii_lowercase();
+            if lower.contains("final-recipient")
+                || lower.contains("original-recipient")
+                || lower.contains("for <")
+                || lower.contains("for ")
+                || lower.contains("recipient:")
+            {
+                return Some(email);
+            }
+
+            if fallback.is_none() && !lower.contains("mailer-daemon") {
+                fallback = Some(email);
+            }
+        }
+    }
+
+    fallback
+}
+
+async fn send_unsubscribe_message(
+    zmq_sender: &ZmqSender,
+    hub_id: i32,
+    email: String,
+    reason: Option<String>,
+) {
+    let message = ZMQUnsubscribeMessage {
+        hub_id,
+        email: email.clone(),
+        reason,
+    };
+
+    match zmq_sender.send_json(&message).await {
+        Ok(_) => log::info!("ZMQ unsubscribe message sent for {email} in hub#{hub_id}"),
+        Err(err) => {
+            log::error!("Cannot send ZMQ unsubscribe message for {email} in hub#{hub_id}: {err}")
+        }
+    }
+}
 
 pub async fn process_reply(
     repo: &DieselRepository,
@@ -86,6 +191,37 @@ pub async fn process_new_message(
             return;
         }
     };
+
+    if let Some(subject) = extract_header_value(header_str, "Subject") {
+        if subject.eq_ignore_ascii_case("unsubscribe") {
+            match extract_sender_email(header_str) {
+                Some(email) => {
+                    send_unsubscribe_message(zmq_sender, hub_id, email, Some(subject.clone()))
+                        .await;
+                    return;
+                }
+                None => log::warn!(
+                    "Received unsubscribe email without sender in hub#{}",
+                    hub_id
+                ),
+            }
+        } else if subject.eq_ignore_ascii_case("Undelivered Mail Returned to Sender") {
+            match fetch_message_body(session, uid).await {
+                Some(body) => match extract_bounce_recipient(&body) {
+                    Some(email) => {
+                        send_unsubscribe_message(zmq_sender, hub_id, email, Some(subject.clone()))
+                            .await;
+                        return;
+                    }
+                    None => log::warn!(
+                        "Undelivered email without identifiable recipient in hub#{}",
+                        hub_id
+                    ),
+                },
+                None => log::warn!("Cannot fetch body for undelivered email in hub#{}", hub_id),
+            }
+        }
+    }
 
     if let Some(recipient_id) = extract_recipient_id(header_str, domain) {
         let reply = fetch_message_body(session, uid)
@@ -218,5 +354,37 @@ pub async fn monitor_hub(
         if let Some(max_uid) = new_uids.iter().max() {
             last_uid = *max_uid;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_header_values_with_folding() {
+        let header = "Subject: Unsubscribe\r\n\trequest\r\nFrom: Name <user@example.com>\r\n";
+        assert_eq!(
+            extract_header_value(header, "Subject"),
+            Some("Unsubscribe request".to_string())
+        );
+    }
+
+    #[test]
+    fn prefers_sender_header_for_email_extraction() {
+        let header = "Sender: sender@example.com\r\nFrom: other@example.com\r\n";
+        assert_eq!(
+            extract_sender_email(header),
+            Some("sender@example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn extracts_bounce_recipient_from_body() {
+        let body = "Final-Recipient: rfc822; bounced@example.com\nMail delivery failed";
+        assert_eq!(
+            extract_bounce_recipient(body),
+            Some("bounced@example.com".to_string())
+        );
     }
 }


### PR DESCRIPTION
## Summary
- detect unsubscribe and undelivered subjects during reply processing and send unsubscribe messages
- parse sender headers and undelivered bodies to derive email addresses
- add helper utilities and unit tests for header and bounce parsing

## Testing
- cargo fmt
- cargo clippy --all-features --tests -- -Dwarnings
- cargo test --all-features

------
https://chatgpt.com/codex/tasks/task_e_68ca985bc200832ab5add99dcead70ad